### PR TITLE
Move record page to nextjs

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -36,7 +36,7 @@ impl actix_web::error::ResponseError for AppError {
 
     fn error_response(&self) -> actix_web::HttpResponse {
         error!("{:?}", self);
-        actix_web::HttpResponse::NotFound().json(serde_json::json!({"error": "TBD"}))
+        actix_web::HttpResponse::NotFound().json(serde_json::json!({"error": self.message}))
     }
 }
 

--- a/api/src/handlers/mod.rs
+++ b/api/src/handlers/mod.rs
@@ -32,5 +32,9 @@ pub fn add_routes(cfg: &mut ServiceConfig) {
     .route(
         "/api/records",
         get().to(crate::handlers::record::records_api),
+    )
+    .route(
+        "/api/records/{record_id}",
+        get().to(crate::handlers::record::record_api),
     );
 }

--- a/api/src/handlers/record.rs
+++ b/api/src/handlers/record.rs
@@ -1,5 +1,5 @@
 use crate::app_state::AppState;
-use crate::db;
+use crate::db::{self, RecordType};
 use crate::error::{AppError, ErrorType};
 use actix_web::{web, HttpResponse};
 use serde::{Deserialize, Serialize};
@@ -9,7 +9,7 @@ use tracing::info;
 pub struct RecordsQuery {
     /// The user search string provided by the user.
     #[serde(rename = "type")]
-    type_: String,
+    type_: RecordType,
     page: Option<u32>,
     puzzle_slug: String,
 }
@@ -28,11 +28,17 @@ pub async fn records_api(
 
     let puzzle_id = match puzzle_id {
         Some(p) => p,
-        None => return Ok(HttpResponse::NotFound().body("puzzle slug doesn't exist")),
+        None => {
+            return Err(AppError {
+                cause: format!("can't find puzzle slug {}", q.puzzle_slug),
+                message: format!("can't find puzzle slug {}", q.puzzle_slug),
+                error_type: ErrorType::NotFound,
+            })
+        }
     };
     info!("{}", puzzle_id);
 
-    let records = db::fetch_records(&app_state.pool, &q.type_, puzzle_id, q.page, 50).await?;
+    let records = db::fetch_records(&app_state.pool, q.type_, puzzle_id, q.page, 50).await?;
 
     Ok(HttpResponse::Ok().json(RecordsResponse { records }))
 }

--- a/api/src/handlers/record.rs
+++ b/api/src/handlers/record.rs
@@ -36,3 +36,12 @@ pub async fn records_api(
 
     Ok(HttpResponse::Ok().json(RecordsResponse { records }))
 }
+
+pub async fn record_api(
+    record_id: web::Path<i32>,
+    app_state: web::Data<AppState>,
+) -> Result<HttpResponse, AppError> {
+    let record = db::fetch_record(&app_state.pool, record_id.into_inner()).await?;
+
+    Ok(HttpResponse::Ok().json(record))
+}

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -46,6 +46,17 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .wrap(TracingLogger::default())
             .app_data(web::Data::new(app_state.clone()))
+            .app_data(web::QueryConfig::default().error_handler(|err, _req| {
+                let err_message = err.to_string();
+
+                actix_web::error::InternalError::from_response(
+                    err,
+                    web::HttpResponse::BadRequest()
+                        .json(serde_json::json!({ "error": err_message }))
+                        .into(),
+                )
+                .into()
+            }))
             .configure(add_routes)
     })
     .bind("0.0.0.0:8081")?

--- a/app/assets/javascripts/models/record.js.coffee
+++ b/app/assets/javascripts/models/record.js.coffee
@@ -4,7 +4,7 @@ class Cubemania.Models.Record extends Backbone.Model
     _.any(@get("singles"), (s) -> s.id == single.get("id"))
 
   getHtmlUrl: (slug) ->
-    "/users/#{slug}/records/#{@get("id")}"
+    "/records/#{@get("id")}"
 
   title: -> # TODO move to RecordPresenter?
     @get("type_full_name")

--- a/frontend/commons/ErrorBoundary.tsx
+++ b/frontend/commons/ErrorBoundary.tsx
@@ -1,0 +1,21 @@
+import React, { ReactNode } from "react";
+import Error from "next/error";
+
+export class ErrorBoundary extends React.Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  public state = { hasError: false };
+
+  static getDerivedStateFromError(_error: unknown) {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <Error statusCode={500}></Error>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/commons/NotFound.tsx
+++ b/frontend/commons/NotFound.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function Custom404() {
+export function NotFound() {
   return (
     <>
       <h1>The page you were looking for doesn't exist.</h1>

--- a/frontend/commons/http/HttpClient.ts
+++ b/frontend/commons/http/HttpClient.ts
@@ -1,0 +1,65 @@
+export class UnauthorizedError extends Error {
+  constructor() {
+    super("HTTP request returned 401");
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class NotFoundError extends Error {
+  constructor() {
+    super("HTTP request returned 404");
+    this.name = "NotFoundError";
+  }
+}
+
+export class RequestError extends Error {
+  statusCode: number;
+  body: unknown;
+
+  constructor(statusCode: number, body: unknown) {
+    super(
+      `HTTP request failed with ${status}. Response: ${JSON.stringify(body)}`
+    );
+    this.name = "RequestError";
+    this.statusCode = statusCode;
+    this.body = body;
+  }
+}
+
+async function request<T>(
+  url: string,
+  method: string,
+  jwtToken?: string
+): Promise<T> {
+  const headers = new Headers();
+  if (jwtToken) {
+    headers.set("Authorization", `Bearer ${jwtToken}`);
+  }
+
+  const response = await fetch(url, { method: method, headers });
+  const content = await response.json();
+
+  if (response.ok) {
+    return content;
+  } else if (response.status === 401) {
+    throw new UnauthorizedError();
+  } else if (response.status === 404) {
+    throw new NotFoundError();
+  } else {
+    throw new RequestError(response.status, content);
+  }
+}
+
+export async function get<T = unknown>(
+  url: string,
+  jwtToken?: string
+): Promise<T> {
+  return request(url, "GET", jwtToken);
+}
+
+export async function put<T = unknown>(
+  url: string,
+  jwtToken?: string
+): Promise<T> {
+  return request(url, "PUT", jwtToken);
+}

--- a/frontend/commons/http/HttpClient.ts
+++ b/frontend/commons/http/HttpClient.ts
@@ -18,7 +18,9 @@ export class RequestError extends Error {
 
   constructor(statusCode: number, body: unknown) {
     super(
-      `HTTP request failed with ${status}. Response: ${JSON.stringify(body)}`
+      `HTTP request failed with ${statusCode}. Response: ${JSON.stringify(
+        body
+      )}`
     );
     this.name = "RequestError";
     this.statusCode = statusCode;

--- a/frontend/commons/text.ts
+++ b/frontend/commons/text.ts
@@ -1,0 +1,5 @@
+/** Capitalizes the string by converting the first character to its uppercase variant.
+ */
+export function capitalize(name: string): string {
+    return name.charAt(0).toUpperCase() + name.slice(1);
+}

--- a/frontend/commons/time.ts
+++ b/frontend/commons/time.ts
@@ -12,6 +12,22 @@ export function formatDate(time: string): string {
   });
 }
 
+/** Formats a time given in ISO8601 format as a long day plus 24h time.
+ *
+ * e.g. "October 16, 2019 at 09:03"
+ *
+ * @param time the time given in ISO8601
+ */
+export function formatDateAndTime(time: string): string {
+  return new Date(time).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  });
+}
+
 /** Formats a given duration in ms to a duration using min and s. Doesn't display
  * the minutes if they are 0.
  *

--- a/frontend/commons/types/assertions.ts
+++ b/frontend/commons/types/assertions.ts
@@ -9,3 +9,11 @@ export function assertNotUndefined<T>(x: T | undefined): T {
 
   return x;
 }
+
+export function assertNotNull<T>(x: T | null, message?: string): T {
+  if (x === null) {
+    throw new Error(message ?? "value should not be undefined");
+  }
+
+  return x;
+}

--- a/frontend/commons/types/assertions.ts
+++ b/frontend/commons/types/assertions.ts
@@ -1,3 +1,11 @@
 export function assertExhausted(_x: never): never {
   throw new Error("not exhausted");
 }
+
+export function assertNotUndefined<T>(x: T | undefined): T {
+  if (x === undefined) {
+    throw new Error("value should not be undefined");
+  }
+
+  return x;
+}

--- a/frontend/commons/types/page.ts
+++ b/frontend/commons/types/page.ts
@@ -3,3 +3,19 @@ export type Page = "Home" | "Timer" | "Users" | "Me" | "Records" | "Post";
 export function eqPage(a: Page, b: Page) {
   return a === b;
 }
+
+export function pageFromPathname(pathName: string): Page | undefined {
+  switch (pathName) {
+    case "/":
+      return "Home";
+    case "/users":
+      return "Users";
+    case "/puzzles/[puzzleId]/records":
+    case "/records/[recordId]":
+      return "Records";
+    case "/_error":
+      return "Home";
+    default:
+      return undefined;
+  }
+}

--- a/frontend/components/ErrorBoundary.tsx
+++ b/frontend/components/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { NextRouter } from "next/router";
+import React, { ReactNode } from "react";
+import Error404 from "../pages/404";
+
+export class ErrorBoundary extends React.Component<
+  { children: ReactNode; router: NextRouter },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; router: NextRouter }) {
+    super(props);
+    this.onRouteChangeComplete = this.onRouteChangeComplete.bind(this);
+  }
+
+  public state = { hasError: false };
+
+  static getDerivedStateFromError(_error: unknown) {
+    return { hasError: true };
+  }
+
+  onRouteChangeComplete() {
+    this.setState({ hasError: false });
+  }
+
+  componentDidMount() {
+    this.props.router.events.on(
+      "routeChangeComplete",
+      this.onRouteChangeComplete
+    );
+  }
+
+  componentWillUnmount() {
+    this.props.router.events.off(
+      "routeChangeComplete",
+      this.onRouteChangeComplete
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <Error404></Error404>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -10,7 +10,7 @@ import { useMe } from "../hooks/useMe";
 import Link from "next/link";
 
 interface HeaderProps {
-  page: Page;
+  page?: Page;
   jwtToken?: string;
 }
 
@@ -18,12 +18,12 @@ interface NavItemProps {
   title: string;
   url: string;
   page: Page;
-  currentPage: Page;
+  currentPage?: Page;
   pushedRight?: boolean;
 }
 
 function NavItem(props: NavItemProps) {
-  const selected = eqPage(props.page, props.currentPage);
+  const selected = props.currentPage && eqPage(props.page, props.currentPage);
 
   return (
     <li

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -9,10 +9,10 @@ import { assertExhausted } from "../commons/types/assertions";
 interface LayoutProps {
   jwtToken?: string;
   puzzleNav?: JSX.Element;
-  page: Page;
+  page?: Page;
 }
 
-function pageTitle(page: Page): string {
+function pageTitle(page: Page | undefined): string {
   switch (page) {
     case "Home":
       return "Home · Cubemania";
@@ -26,6 +26,8 @@ function pageTitle(page: Page): string {
       return "User · Cubemania";
     case "Records":
       return "Records · Cubemania";
+    case undefined:
+      return "Cubemania";
     default:
       return assertExhausted(page);
   }

--- a/frontend/components/NotFoundErrorBoundary.tsx
+++ b/frontend/components/NotFoundErrorBoundary.tsx
@@ -1,8 +1,9 @@
 import { NextRouter } from "next/router";
 import React, { ReactNode } from "react";
-import Error404 from "../pages/404";
+import { NotFoundError } from "../commons/http/HttpClient";
+import { NotFound } from "../commons/NotFound";
 
-export class ErrorBoundary extends React.Component<
+export class NotFoundErrorBoundary extends React.Component<
   { children: ReactNode; router: NextRouter },
   { hasError: boolean }
 > {
@@ -17,11 +18,21 @@ export class ErrorBoundary extends React.Component<
     return { hasError: true };
   }
 
+  componentDidCatch(error: unknown, _errorInfo: unknown) {
+    if (!(error instanceof NotFoundError)) {
+      throw error;
+    }
+  }
+
   onRouteChangeComplete() {
     this.setState({ hasError: false });
   }
 
   componentDidMount() {
+    // NOTE: Listening on route changes and clearing the error state is
+    // necessary, otherwise using the back button after seeing a 404 error
+    // won't have any effect.
+    // See also https://stackoverflow.com/q/48121750.
     this.props.router.events.on(
       "routeChangeComplete",
       this.onRouteChangeComplete
@@ -37,7 +48,7 @@ export class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return <Error404></Error404>;
+      return <NotFound></NotFound>;
     }
 
     return this.props.children;

--- a/frontend/hooks/useAnnouncement.ts
+++ b/frontend/hooks/useAnnouncement.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query";
+import { get } from "../commons/http/HttpClient";
 
 type AnnouncementResponse = null | {
   id: number;
@@ -8,8 +9,7 @@ type AnnouncementResponse = null | {
 };
 
 export function useAnnouncement() {
-  return useQuery<AnnouncementResponse, Error>(["announcement"], async () => {
-    const r = await fetch("/api/announcement");
-    return await r.json();
-  });
+  return useQuery(["announcement"], async () =>
+    get<AnnouncementResponse>("/api/announcement")
+  );
 }

--- a/frontend/hooks/useBlockUser.ts
+++ b/frontend/hooks/useBlockUser.ts
@@ -1,19 +1,12 @@
 import { useMutation, useQueryClient } from "react-query";
+import { put } from "../commons/http/HttpClient";
 
 export function useBlockUser(jwtToken?: string) {
   const queryClient = useQueryClient();
 
   return useMutation(
     async (slug: string) => {
-      const headers = new Headers();
-      if (jwtToken) {
-        headers.set("Authorization", `Bearer ${jwtToken}`);
-      }
-      const r = await fetch(`/api/users/${slug}/block`, {
-        headers,
-        method: "PUT",
-      });
-      return await r.json();
+      return await put(`/api/users/${slug}/block`, jwtToken);
     },
     {
       onSuccess: () => {

--- a/frontend/hooks/usePuzzleFromUrl.ts
+++ b/frontend/hooks/usePuzzleFromUrl.ts
@@ -1,11 +1,6 @@
+import { assertNotNull } from "../commons/types/assertions";
 import { useSingleQueryParam } from "./useSingleQueryParam";
 
 export function usePuzzleFromUrl(): string {
-  const q = useSingleQueryParam("puzzleId");
-
-  if (q === null) {
-    throw new Error("routing error");
-  } else {
-    return q;
-  }
+  return assertNotNull(useSingleQueryParam("puzzleId"), "routing error");
 }

--- a/frontend/hooks/usePuzzles.ts
+++ b/frontend/hooks/usePuzzles.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query";
+import { get } from "../commons/http/HttpClient";
 
 export interface Puzzle {
   css_position: number;
@@ -17,10 +18,7 @@ export interface Kind {
 export function usePuzzles() {
   return useQuery<Kind[]>(
     "allPuzzles",
-    async () => {
-      const response = await fetch("/api/puzzles");
-      return await response.json();
-    },
+    async () => get<Kind[]>("/api/puzzles"),
     { staleTime: Infinity }
   );
 }

--- a/frontend/hooks/useRecord.ts
+++ b/frontend/hooks/useRecord.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query";
+import { get } from "../commons/http/HttpClient";
 
 interface Single {
   id: number;
@@ -23,8 +24,9 @@ export interface Record {
 }
 
 export function useRecord(recordId: number) {
-  return useQuery<Record>(["record", recordId], async () => {
-    let response = await fetch(`/api/records/${recordId}`);
-    return await response.json();
-  });
+  return useQuery<Record>(
+    ["record", recordId],
+    async () => get(`/api/records/${recordId}`),
+    { retry: false }
+  );
 }

--- a/frontend/hooks/useRecord.ts
+++ b/frontend/hooks/useRecord.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "react-query";
 
 interface Single {
+  id: number;
   time: number;
+  penalty?: "DNF" | "PLUS2";
   scramble: string;
   comment: string;
 }

--- a/frontend/hooks/useRecord.ts
+++ b/frontend/hooks/useRecord.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "react-query";
+
+interface Single {
+  time: number;
+  scramble: string;
+  comment: string;
+}
+
+export interface Record {
+  id: number;
+  time: number;
+  amount: number;
+  set_at: string;
+  user_name: string;
+  user_slug: string;
+  puzzle_name: string;
+  kind_short_name?: string;
+  puzzle_css_position: string;
+  kind_css_position: string;
+  singles: Single[];
+}
+
+export function useRecord(recordId: number) {
+  return useQuery<Record>(["record", recordId], async () => {
+    let response = await fetch(`/api/records/${recordId}`);
+    return await response.json();
+  });
+}

--- a/frontend/hooks/useRecordIdFromUrl.ts
+++ b/frontend/hooks/useRecordIdFromUrl.ts
@@ -1,7 +1,7 @@
 import { useSingleQueryParam } from "./useSingleQueryParam";
 
-export function usePuzzleFromUrl(): string {
-  const q = useSingleQueryParam("puzzleId");
+export function useRecordIdFromUrl(): string {
+  const q = useSingleQueryParam("recordId");
 
   if (q === null) {
     throw new Error("routing error");

--- a/frontend/hooks/useRecordIdFromUrl.ts
+++ b/frontend/hooks/useRecordIdFromUrl.ts
@@ -1,11 +1,6 @@
+import { assertNotNull } from "../commons/types/assertions";
 import { useSingleQueryParam } from "./useSingleQueryParam";
 
 export function useRecordIdFromUrl(): string {
-  const q = useSingleQueryParam("recordId");
-
-  if (q === null) {
-    throw new Error("routing error");
-  } else {
-    return q;
-  }
+  return assertNotNull(useSingleQueryParam("recordId"), "routing error");
 }

--- a/frontend/hooks/useRecords.ts
+++ b/frontend/hooks/useRecords.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "react-query";
+import { get } from "../commons/http/HttpClient";
 import { PaginatedResponse } from "../commons/types/PaginatedResponse";
 
 export interface Record {
@@ -18,12 +19,8 @@ interface RecordResponse {
 export function useRecords(type: string, page: number, puzzleSlug: string) {
   return useQuery<RecordResponse>(
     ["records", puzzleSlug, type, page],
-    async () => {
-      let response = await fetch(
-        `/api/records?type=${type}&page=${page}&puzzle_slug=${puzzleSlug}`
-      );
-      return await response.json();
-    },
+    async () =>
+      get(`/api/records?type=${type}&page=${page}&puzzle_slug=${puzzleSlug}`),
     { keepPreviousData: true }
   );
 }

--- a/frontend/hooks/useUsersIndexData.ts
+++ b/frontend/hooks/useUsersIndexData.ts
@@ -1,4 +1,5 @@
 import { InfiniteData, useInfiniteQuery, useQuery } from "react-query";
+import { get } from "../commons/http/HttpClient";
 import { PaginatedResponse } from "../commons/types/PaginatedResponse";
 
 interface SimpleUser {
@@ -35,14 +36,7 @@ export function useUsersIndexData({
     Error
   >(
     ["max_singles_record"],
-    async () => {
-      const headers = new Headers();
-      headers.set("Authorization", `Bearer ${jwtToken}`);
-      const r = await fetch("/api/max_singles_record", {
-        headers,
-      });
-      return await r.json();
-    },
+    async () => get("/api/max_singles_record", jwtToken),
     // Setting stale time to infinity since this data rarely changes, no need
     // to refetch the data.
     { staleTime: Infinity }
@@ -60,12 +54,7 @@ export function useUsersIndexData({
       if (searchTerm !== null) {
         queryParam.append("q", searchTerm);
       }
-      const headers = new Headers();
-      headers.set("Authorization", `Bearer ${jwtToken}`);
-      const r = await fetch(`/api/users?${queryParam}`, {
-        headers,
-      });
-      return await r.json();
+      return await get(`/api/users?${queryParam}`, jwtToken);
     },
     {
       getNextPageParam: (lastPage, _pages) => lastPage.users.next_page,

--- a/frontend/models/recordTypes.ts
+++ b/frontend/models/recordTypes.ts
@@ -1,5 +1,13 @@
+import { assertNotUndefined } from "../commons/types/assertions";
+
 export const RecordTypes = [
   { name: "Single", short: "single", amount: 1 },
   { name: "Average of 5", short: "avg5", amount: 5 },
   { name: "Average of 12", short: "avg12", amount: 12 },
 ] as const;
+
+export function findRecordTypeByAmount(
+  amount: number
+): typeof RecordTypes[number] {
+  return assertNotUndefined(RecordTypes.find((r) => r.amount === amount));
+}

--- a/frontend/pages/404.tsx
+++ b/frontend/pages/404.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Layout } from "../components/Layout";
+
+export default function Custom404() {
+  return (
+    <Layout page={"Records"}>
+      <h1>The page you were looking for doesn't exist.</h1>
+      <p>You may have mistyped the address or the page may have moved.</p>
+    </Layout>
+  );
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,10 +4,15 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import "../styles/globals.css.scss";
 import { useRouter } from "next/router";
-import { ErrorBoundary } from "../components/ErrorBoundary";
+import { NotFoundErrorBoundary } from "../components/NotFoundErrorBoundary";
+import { Layout } from "../components/Layout";
+import { pageFromPathname } from "../commons/types/page";
+import { PuzzleNav } from "../components/PuzzleNav";
+import { ErrorBoundary } from "../commons/ErrorBoundary";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
+  const currentMenuPage = pageFromPathname(router.pathname);
   const queryClientRef = useRef<QueryClient>();
   const jwtToken = useRef<string>(pageProps.jwtToken);
 
@@ -23,19 +28,31 @@ function MyApp({ Component, pageProps }: AppProps) {
   if (!queryClientRef.current) {
     queryClientRef.current = new QueryClient({
       defaultOptions: {
-        queries: { useErrorBoundary: true },
+        queries: { useErrorBoundary: true, retry: false },
         mutations: { useErrorBoundary: true },
       },
     });
   }
 
   return (
-    <QueryClientProvider client={queryClientRef.current}>
-      <ReactQueryDevtools initialIsOpen={false} />
-      <ErrorBoundary router={router}>
-        <Component {...pageProps} jwtToken={jwtToken.current} />
-      </ErrorBoundary>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClientRef.current}>
+        <ReactQueryDevtools initialIsOpen={false} />
+        <Layout
+          jwtToken={jwtToken.current}
+          page={currentMenuPage}
+          puzzleNav={
+            router.pathname === "/puzzles/[puzzleId]/records" ? (
+              <PuzzleNav />
+            ) : undefined
+          }
+        >
+          <NotFoundErrorBoundary router={router}>
+            <Component {...pageProps} jwtToken={jwtToken.current} />
+          </NotFoundErrorBoundary>
+        </Layout>
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,10 +1,13 @@
 import App, { AppProps, AppContext } from "next/app";
-import { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import "../styles/globals.css.scss";
+import { useRouter } from "next/router";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
   const queryClientRef = useRef<QueryClient>();
   const jwtToken = useRef<string>(pageProps.jwtToken);
 
@@ -18,13 +21,20 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, [pageProps.jwtToken]);
 
   if (!queryClientRef.current) {
-    queryClientRef.current = new QueryClient();
+    queryClientRef.current = new QueryClient({
+      defaultOptions: {
+        queries: { useErrorBoundary: true },
+        mutations: { useErrorBoundary: true },
+      },
+    });
   }
 
   return (
     <QueryClientProvider client={queryClientRef.current}>
       <ReactQueryDevtools initialIsOpen={false} />
-      <Component {...pageProps} jwtToken={jwtToken.current} />
+      <ErrorBoundary router={router}>
+        <Component {...pageProps} jwtToken={jwtToken.current} />
+      </ErrorBoundary>
     </QueryClientProvider>
   );
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Layout } from "../components/Layout";
 import {
   postPath,
   records3x3x3Path,
@@ -8,10 +7,6 @@ import {
 } from "../commons/path";
 import { useAnnouncement } from "../hooks/useAnnouncement";
 import ReactMarkdown from "react-markdown";
-
-interface HomeProps {
-  jwtToken?: string;
-}
 
 interface AnnouncementProps {
   url: string;
@@ -32,11 +27,11 @@ function Announcement(props: AnnouncementProps) {
   );
 }
 
-export default function Home(props: HomeProps) {
+export default function Home() {
   const { data } = useAnnouncement();
 
   return (
-    <Layout jwtToken={props.jwtToken} page={"Home"}>
+    <>
       {data && (
         <Announcement
           title={data.title}
@@ -80,6 +75,6 @@ export default function Home(props: HomeProps) {
           <p>Get the record!</p>
         </li>
       </ul>
-    </Layout>
+    </>
   );
 }

--- a/frontend/pages/puzzles/[puzzleId]/records/index.tsx
+++ b/frontend/pages/puzzles/[puzzleId]/records/index.tsx
@@ -4,8 +4,6 @@ import { pages } from "../../../../commons/paginator";
 import { recordsPath, userPath } from "../../../../commons/path";
 import { formatDate, formatDuration } from "../../../../commons/time";
 import { PaginatedResponse } from "../../../../commons/types/PaginatedResponse";
-import { Layout } from "../../../../components/Layout";
-import { PuzzleNav } from "../../../../components/PuzzleNav";
 import { useBlockUser } from "../../../../hooks/useBlockUser";
 import { useMyRole } from "../../../../hooks/useMyRole";
 import { usePuzzleFromUrl } from "../../../../hooks/usePuzzleFromUrl";
@@ -189,11 +187,7 @@ export default function Records(props: RecordsProps) {
   const { data } = useRecords(currentType, page, currentPuzzleSlug);
 
   return (
-    <Layout
-      jwtToken={props.jwtToken}
-      puzzleNav={<PuzzleNav />}
-      page={"Records"}
-    >
+    <>
       <RecordTypeTabs />
       {data && (
         <RecordTable
@@ -210,6 +204,6 @@ export default function Records(props: RecordsProps) {
           records={data.records}
         />
       )}
-    </Layout>
+    </>
   );
 }

--- a/frontend/pages/records/[recordId].tsx
+++ b/frontend/pages/records/[recordId].tsx
@@ -51,10 +51,10 @@ export default function Record(props: RecordProps) {
           </thead>
           <tbody>
             {data.singles.map((single, i) => (
-              <tr className={(i + 1) % 2 ? "even" : "odd"}>
+              <tr key={single.id} className={(i + 1) % 2 ? "even" : "odd"}>
                 <td>{i + 1}</td>
                 <td>
-                  <strong className="time">
+                  <strong className={`time ${single.penalty?.toLowerCase()}`}>
                     {formatDuration(single.time)}
                   </strong>
                 </td>

--- a/frontend/pages/records/[recordId].tsx
+++ b/frontend/pages/records/[recordId].tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import React from "react";
+import { userPath } from "../../commons/path";
+import { capitalize } from "../../commons/text";
+import { formatDateAndTime, formatDuration } from "../../commons/time";
+import { Layout } from "../../components/Layout";
+import { useRecord } from "../../hooks/useRecord";
+import { useRecordIdFromUrl } from "../../hooks/useRecordIdFromUrl";
+import { findRecordTypeByAmount } from "../../models/recordTypes";
+
+interface RecordProps {
+  jwtToken?: string;
+}
+
+export default function Record(props: RecordProps) {
+  const recordId = parseInt(useRecordIdFromUrl(), 10);
+  const { data } = useRecord(recordId);
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <Layout jwtToken={props.jwtToken} page={"Records"}>
+      <h1>
+        <Link href={userPath(data.user_slug)}>
+          <a>{capitalize(data.user_name)}'s</a>
+        </Link>{" "}
+        {findRecordTypeByAmount(data.amount).name} Record
+      </h1>
+
+      <article id="record">
+        <header>
+          <h2>{formatDuration(data.time)}</h2>
+          <small>{formatDateAndTime(data.set_at)}</small>
+          <div className={`puzzle pos${data.puzzle_css_position}`}>
+            <div className={`kind pos${data.kind_css_position}`}>
+              {data.puzzle_name} {data.kind_short_name}
+            </div>
+          </div>
+        </header>
+
+        <table id="singles">
+          <thead>
+            <tr>
+              <th>Solve</th>
+              <th>Time</th>
+              <th>Scramble</th>
+              <th>Comment</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.singles.map((single, i) => (
+              <tr className={(i + 1) % 2 ? "even" : "odd"}>
+                <td>{i + 1}</td>
+                <td>
+                  <strong className="time">
+                    {formatDuration(single.time)}
+                  </strong>
+                </td>
+                <td>
+                  <small>{single.scramble}</small>
+                </td>
+                <td>{single.comment}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+    </Layout>
+  );
+}

--- a/frontend/pages/records/[recordId].tsx
+++ b/frontend/pages/records/[recordId].tsx
@@ -3,21 +3,16 @@ import React from "react";
 import { userPath } from "../../commons/path";
 import { capitalize } from "../../commons/text";
 import { formatDateAndTime, formatDuration } from "../../commons/time";
-import { Layout } from "../../components/Layout";
 import { useRecord } from "../../hooks/useRecord";
 import { useRecordIdFromUrl } from "../../hooks/useRecordIdFromUrl";
 import { findRecordTypeByAmount } from "../../models/recordTypes";
 
-interface RecordProps {
-  jwtToken?: string;
-}
-
-export default function Record(props: RecordProps) {
+export default function Record() {
   const recordId = parseInt(useRecordIdFromUrl(), 10);
   const { data } = useRecord(recordId);
 
   return (
-    <Layout jwtToken={props.jwtToken} page={"Records"}>
+    <>
       {data && (
         <>
           <h1>
@@ -69,6 +64,6 @@ export default function Record(props: RecordProps) {
           </article>
         </>
       )}
-    </Layout>
+    </>
   );
 }

--- a/frontend/pages/records/[recordId].tsx
+++ b/frontend/pages/records/[recordId].tsx
@@ -16,57 +16,59 @@ export default function Record(props: RecordProps) {
   const recordId = parseInt(useRecordIdFromUrl(), 10);
   const { data } = useRecord(recordId);
 
-  if (!data) {
-    return null;
-  }
-
   return (
     <Layout jwtToken={props.jwtToken} page={"Records"}>
-      <h1>
-        <Link href={userPath(data.user_slug)}>
-          <a>{capitalize(data.user_name)}'s</a>
-        </Link>{" "}
-        {findRecordTypeByAmount(data.amount).name} Record
-      </h1>
+      {data && (
+        <>
+          <h1>
+            <Link href={userPath(data.user_slug)}>
+              <a>{capitalize(data.user_name)}'s</a>
+            </Link>{" "}
+            {findRecordTypeByAmount(data.amount).name} Record
+          </h1>
 
-      <article id="record">
-        <header>
-          <h2>{formatDuration(data.time)}</h2>
-          <small>{formatDateAndTime(data.set_at)}</small>
-          <div className={`puzzle pos${data.puzzle_css_position}`}>
-            <div className={`kind pos${data.kind_css_position}`}>
-              {data.puzzle_name} {data.kind_short_name}
-            </div>
-          </div>
-        </header>
+          <article id="record">
+            <header>
+              <h2>{formatDuration(data.time)}</h2>
+              <small>{formatDateAndTime(data.set_at)}</small>
+              <div className={`puzzle pos${data.puzzle_css_position}`}>
+                <div className={`kind pos${data.kind_css_position}`}>
+                  {data.puzzle_name} {data.kind_short_name}
+                </div>
+              </div>
+            </header>
 
-        <table id="singles">
-          <thead>
-            <tr>
-              <th>Solve</th>
-              <th>Time</th>
-              <th>Scramble</th>
-              <th>Comment</th>
-            </tr>
-          </thead>
-          <tbody>
-            {data.singles.map((single, i) => (
-              <tr key={single.id} className={(i + 1) % 2 ? "even" : "odd"}>
-                <td>{i + 1}</td>
-                <td>
-                  <strong className={`time ${single.penalty?.toLowerCase()}`}>
-                    {formatDuration(single.time)}
-                  </strong>
-                </td>
-                <td>
-                  <small>{single.scramble}</small>
-                </td>
-                <td>{single.comment}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </article>
+            <table id="singles">
+              <thead>
+                <tr>
+                  <th>Solve</th>
+                  <th>Time</th>
+                  <th>Scramble</th>
+                  <th>Comment</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.singles.map((single, i) => (
+                  <tr key={single.id} className={(i + 1) % 2 ? "even" : "odd"}>
+                    <td>{i + 1}</td>
+                    <td>
+                      <strong
+                        className={`time ${single.penalty?.toLowerCase()}`}
+                      >
+                        {formatDuration(single.time)}
+                      </strong>
+                    </td>
+                    <td>
+                      <small>{single.scramble}</small>
+                    </td>
+                    <td>{single.comment}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </article>
+        </>
+      )}
     </Layout>
   );
 }

--- a/frontend/pages/users/index.tsx
+++ b/frontend/pages/users/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { useCallback } from "react";
 import { userPath } from "../../commons/path";
-import { Layout } from "../../components/Layout";
 import { useUsersIndexData } from "../../hooks/useUsersIndexData";
 
 interface UserProps {
@@ -43,7 +42,7 @@ export default function Users(props: UsersProps) {
   }, []);
 
   return (
-    <Layout jwtToken={props.jwtToken} page={"Users"}>
+    <>
       <form
         acceptCharset="UTF-8"
         action="/users"
@@ -91,6 +90,6 @@ export default function Users(props: UsersProps) {
           </a>
         </div>
       )}
-    </Layout>
+    </>
   );
 }

--- a/frontend/styles/_content.css.scss
+++ b/frontend/styles/_content.css.scss
@@ -123,6 +123,9 @@ div.fancybox-inner {
     color: rgba(255, 255, 255, 0.3);
     text-decoration: line-through;
   }
+  .time.plus2:after {
+    content: "+";
+  }
   .time.best {
     color: rgba(0, 255, 0, 0.6);
   }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,6 +44,11 @@ http {
 
         #access_log  logs/host.access.log  main;
 
+        # Theses URLs have been shared on Facebook, redirect them properly.
+        location ~* ^/users/[^/]+/records/(\d+)$ {
+          return 301 $scheme://$http_host/records/$1;
+        }
+
         location ~* ^/assets/ {
           root /home/assets;
           expires 1y;
@@ -235,6 +240,11 @@ http {
         include ssl.conf*;
 
         #access_log  logs/host.access.log  main;
+
+        # Theses URLs have been shared on Facebook, redirect them properly.
+        location ~* ^/users/[^/]+/records/(\d+)$ {
+          return 301 $scheme://$http_host/records/$1;
+        }
 
         location ~* ^/assets/ {
           root /home/assets;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -120,6 +120,14 @@ http {
           proxy_set_header   X-Forwarded-Host $http_host;
         }
 
+        location ~* ^/records/[0-9]+$ {
+          proxy_pass http://frontend_servers;
+          proxy_redirect off;
+          proxy_set_header Host $http_host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Host $http_host;
+        }
         location ~* ^/puzzles/[^/]+/records {
           proxy_pass http://frontend_servers;
           proxy_redirect off;
@@ -304,6 +312,14 @@ http {
           proxy_set_header   X-Forwarded-Host $http_host;
         }
 
+        location ~* ^/records/[0-9]+$ {
+          proxy_pass http://frontend_servers;
+          proxy_redirect off;
+          proxy_set_header Host $http_host;
+          proxy_set_header   X-Real-IP $remote_addr;
+          proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header   X-Forwarded-Host $http_host;
+        }
         location ~* ^/puzzles/[^/]+/records {
           proxy_pass http://frontend_servers;
           proxy_redirect off;


### PR DESCRIPTION
Changes route from /users/[slug]/records/[id] to just /records[id] in
the process.

# Todo

* [x] Handle 404s gracefully.
* [x] Redirect old URLs to new URL at nginx level (have been shared using Facebook).